### PR TITLE
ix(links): fix link generation query param

### DIFF
--- a/src/links.tsx
+++ b/src/links.tsx
@@ -52,7 +52,9 @@ export function generateLink<
           value.forEach(item => acc.append(key, item))
           return acc
         }
-        acc.set(key, String(value))
+        if (value !== undefined && value !== null) {
+          acc.set(key, String(value))
+        }
         return acc
       }, new URLSearchParams()).toString()
 


### PR DESCRIPTION
Don't add undefiend query parmas on link generation